### PR TITLE
Fix: Route informational server logs to stdout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ class ConfigurableCommandServer {
       const configContent = await fs.readFile(this.configPath, "utf-8");
       const rawConfig = JSON.parse(configContent);
       this.config = ConfigSchema.parse(rawConfig);
-      console.error(`Loaded configuration from ${this.configPath}`);
+      console.log(`Loaded configuration from ${this.configPath}`);
     } catch (error) {
       console.error(`Failed to load configuration: ${error}`);
       // Load default configuration
@@ -452,7 +452,7 @@ class ConfigurableCommandServer {
     await this.loadConfiguration();
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    console.error("MCP Server running on stdio");
+    console.log("MCP Server running on stdio");
   }
 }
 


### PR DESCRIPTION
I changed two logging statements in `src/index.ts` from `console.error` to `console.log`:
- The message indicating where the configuration was loaded from.
- The message indicating that the MCP server is running on stdio.

This prevents these informational messages from being captured as errors by test scripts like `test/test-file-reading.js`, which previously reported them as "Server error:", potentially causing confusion.

I ran the test `test/test-file-reading.js` to confirm that these messages no longer appear as errors and that the test continues to pass with an exit code of 0.