### PR TITLE
Fix: Correct schema generation, CWD for tools, and add tests

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -11,9 +11,9 @@
           "description": "Array of document paths to read (supports .pdf, .doc, .docx, .html, .htm)",
           "required": true,
           "items": {
-            "type": "string"
-          },
-          "pattern": "^[^\\x00-\\x1f;&|`$(){}\\[\\]<>'\"\\\\]+\\.(pdf|doc|docx|html|htm)$"
+            "type": "string",
+            "pattern": "^[^\\x00-\\x1f;&|`$(){}\\[\\]<>'\"\\\\]+\\.(pdf|doc|docx|html|htm)$"
+          }
         }
       },
       "allowedDirectories": ["/Users/dewoller"],


### PR DESCRIPTION
This commit addresses several issues:

1.  **Schema Generation for Array Parameters:**
    - Modified `ToolConfigSchema` to allow `pattern` on `items` of array parameters.
    - Corrected `inputSchema` generation in `ListToolsRequestSchema` handler:
        - Patterns for array items are now correctly placed in `properties.key.items.pattern`.
        - `pattern` is no longer incorrectly placed directly on array properties in the schema.
    - Updated `tools.json` to move the pattern for `read_docs_by_list.files` into `items.pattern`.
    - This should resolve client-side errors like "Cannot read properties of undefined (reading 'files')" when parsing tool schemas.

2.  **Command Execution Context:**
    - Set `cwd: os.tmpdir()` for commands spawned by `executeCommand`.
    - This provides a consistent and usually writable current working directory, aiming to prevent errors like "Current directory not allowed: /".

3.  **Enhanced Testing:**
    - Updated `test/test-file-reading.js`: - Added assertions to verify the correct structure of `inputSchema` for `read_docs_by_list` (pattern on items, not array). - Added a check to ensure "Current directory not allowed: /" does not appear in `stderr` during test execution.
    - All tests pass with these changes.